### PR TITLE
Set GitHub push user as BUILD_USER_ID

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/SCMTriggerCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/SCMTriggerCauseDeterminant.java
@@ -3,8 +3,10 @@ package org.jenkinsci.plugins.builduser.varsetter.impl;
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.SCMTrigger.SCMTriggerCause;
 
+import java.lang.reflect.Field;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.builduser.utils.UsernameUtils;
 import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
 
@@ -18,6 +20,18 @@ public class SCMTriggerCauseDeterminant implements IUsernameSettable<SCMTrigger.
         if (cause != null) {
 			UsernameUtils.setUsernameVars("SCMTrigger", variables);
 			
+			// sets pushedBy provided by GitHubPushCause as BUILD_USER_ID
+			try {
+				Field pushedByField = cause.getClass().getDeclaredField("pushedBy");
+				pushedByField.setAccessible(true);
+				String pushedBy = (String) pushedByField.get(cause);
+				if (StringUtils.isNotEmpty(pushedBy)) {
+					variables.put(BUILD_USER_ID, pushedBy);
+				}
+			} catch (ReflectiveOperationException exception) {
+				// do nothing 
+			}
+
 			return true;
 		} else {
 			return false;


### PR DESCRIPTION
The GitHub plugin provides the id of the user who triggers a build by a push to GitHub. We would like to set this user in the environment variable BUILD_USER_ID.