### PR TITLE
fix the name which appears in Update Center

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<artifactId>build-user-vars-plugin</artifactId>
 	<version>1.6-SNAPSHOT</version>
 	<packaging>hpi</packaging>
-	<name>Jenkins user build vars plugin</name>
+	<name>Jenkins build user vars plugin</name>
 	<description>Sets username build variables</description>
 
 	<url>http://wiki.jenkins-ci.org/display/JENKINS/Build+User+Vars+Plugin</url>


### PR DESCRIPTION
It is called "build user vars", not "user build vars"... Took me quite a while to find it in my installation... ;)