### PR TITLE
Multiple issues fixed/enhanced

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
@@ -85,9 +85,6 @@ public class BuildUser extends SimpleBuildWrapper {
 			return;
 		}
 
-		// Other causes should be checked after as build can be triggered automatically and later rerun manually by a human.
-		// In that case there will be multiple causes and the direct manually one is preferred to set in a variable.
-
 		// If build has been triggered form an upstream build, get UserCause from there to set user build variables
         Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause) build.getCause(Cause.UpstreamCause.class);
         if (upstreamCause != null) {
@@ -100,6 +97,12 @@ public class BuildUser extends SimpleBuildWrapper {
             }
         }
 
+		// Other causes should be checked after as build can be triggered automatically and later rerun manually by a human.
+		// In that case there will be multiple causes and the direct manually one is preferred to set in a variable.
+		handleOtherCausesOrLogWarningIfUnhandled(build, variables);
+	}
+
+	private void handleOtherCausesOrLogWarningIfUnhandled(@Nonnull Run build, @Nonnull Map<String, String> variables) {
 		// set BUILD_USER_NAME and ID to fixed value if the build was triggered by a change in the scm, timer or remotly with token
 		SCMTrigger.SCMTriggerCause scmTriggerCause = (SCMTrigger.SCMTriggerCause) build.getCause(SCMTrigger.SCMTriggerCause.class);
 		if (new SCMTriggerCauseDeterminant().setJenkinsUserBuildVars(scmTriggerCause, variables)) {

--- a/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
@@ -23,6 +23,7 @@ import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildWrapper;
 
 import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
+import org.jenkinsci.plugins.builduser.varsetter.impl.RemoteCauseDeterminant;
 import org.jenkinsci.plugins.builduser.varsetter.impl.SCMTriggerCauseDeterminant;
 import org.jenkinsci.plugins.builduser.varsetter.impl.TimerTriggerCauseDeterminant;
 import org.jenkinsci.plugins.builduser.varsetter.impl.UserCauseDeterminant;
@@ -92,15 +93,19 @@ public class BuildUser extends SimpleBuildWrapper {
             }
         }
 
-		// set BUILD_USER_NAME and ID to fixed value if the build was triggered by a change in the scm
+		// set BUILD_USER_NAME and ID to fixed value if the build was triggered by a change in the scm, timer or remotly with token
 		SCMTrigger.SCMTriggerCause scmTriggerCause = (SCMTrigger.SCMTriggerCause) build.getCause(SCMTrigger.SCMTriggerCause.class);
 		if (new SCMTriggerCauseDeterminant().setJenkinsUserBuildVars(scmTriggerCause, variables)) {
 			return;
 		}
 
-		// set BUILD_USER_NAME and ID to fixed value if the build was triggered by a timer
 		TimerTrigger.TimerTriggerCause timerTriggerCause = (TimerTrigger.TimerTriggerCause) build.getCause(TimerTrigger.TimerTriggerCause.class);
 		if (new TimerTriggerCauseDeterminant().setJenkinsUserBuildVars(timerTriggerCause, variables)) {
+			return;
+		}
+
+		Cause.RemoteCause remoteTriggerCause = (Cause.RemoteCause) build.getCause(Cause.RemoteCause.class);
+		if (new RemoteCauseDeterminant().setJenkinsUserBuildVars(remoteTriggerCause, variables)) {
 			return;
 		}
     }

--- a/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
@@ -42,7 +42,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * 
  * @author GKonovalenko
  */
-@SuppressWarnings("deprecation")
 public class BuildUser extends SimpleBuildWrapper {
 
 	private static final Logger log = Logger.getLogger(BuildUser.class.getName());
@@ -80,6 +79,7 @@ public class BuildUser extends SimpleBuildWrapper {
 		}
 
 		// Try to use deprecated UserCause to get & set jenkins user build variables
+		@SuppressWarnings("deprecation")
 		UserCause userCause = (UserCause) build.getCause(UserCause.class);
 		if(new UserCauseDeterminant().setJenkinsUserBuildVars(userCause, variables)) {
 			return;

--- a/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
@@ -1,4 +1,7 @@
 package org.jenkinsci.plugins.builduser;
+
+import static java.lang.String.format;
+
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -16,12 +19,14 @@ import hudson.triggers.SCMTrigger;
 import java.io.IOException;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
 import hudson.triggers.TimerTrigger;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildWrapper;
 
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
 import org.jenkinsci.plugins.builduser.varsetter.impl.RemoteCauseDeterminant;
 import org.jenkinsci.plugins.builduser.varsetter.impl.SCMTriggerCauseDeterminant;
@@ -39,6 +44,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 @SuppressWarnings("deprecation")
 public class BuildUser extends SimpleBuildWrapper {
+
+	private static final Logger log = Logger.getLogger(BuildUser.class.getName());
 
 	private static final String EXTENSION_DISPLAY_NAME = "Set jenkins user build variables";
 
@@ -108,8 +115,9 @@ public class BuildUser extends SimpleBuildWrapper {
 		if (new RemoteCauseDeterminant().setJenkinsUserBuildVars(remoteTriggerCause, variables)) {
 			return;
 		}
-    }
 
+		log.warning(format("Unsupported cause type(s): %s", StringUtils.join(build.getCauses().iterator(), ", ")));
+	}
 
 	@Extension
 	public static class DescriptorImpl extends BuildWrapperDescriptor {

--- a/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
@@ -86,16 +86,17 @@ public class BuildUser extends SimpleBuildWrapper {
 		}
 
 		// If build has been triggered form an upstream build, get UserCause from there to set user build variables
-        Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause) build.getCause(Cause.UpstreamCause.class);
-        if (upstreamCause != null) {
-            Job job = Jenkins.getInstance().getItemByFullName(upstreamCause.getUpstreamProject(), Job.class);
-            if (job != null) {
-	        Run upstream = job.getBuildByNumber(upstreamCause.getUpstreamBuild());
-	        if (upstream != null) {
-	            makeUserBuildVariables(upstream, variables);
-	        }
-            }
-        }
+		Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause) build.getCause(Cause.UpstreamCause.class);
+		if (upstreamCause != null) {
+			Job job = Jenkins.getInstance().getItemByFullName(upstreamCause.getUpstreamProject(), Job.class);
+			if (job != null) {
+				Run upstream = job.getBuildByNumber(upstreamCause.getUpstreamBuild());
+				if (upstream != null) {
+					makeUserBuildVariables(upstream, variables);
+					return;
+				}
+			}
+		}
 
 		// Other causes should be checked after as build can be triggered automatically and later rerun manually by a human.
 		// In that case there will be multiple causes and the direct manually one is preferred to set in a variable.

--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/RemoteCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/RemoteCauseDeterminant.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.builduser.varsetter.impl;
 
+import static java.lang.String.format;
+
 import java.util.Map;
 
 import org.jenkinsci.plugins.builduser.utils.UsernameUtils;
@@ -16,7 +18,7 @@ public class RemoteCauseDeterminant implements IUsernameSettable<Cause.RemoteCau
         }
 
         //As of Jenkins 2.51 remote cause is set the build was triggered using token and real user is not set
-        UsernameUtils.setUsernameVars(cause.getShortDescription(), variables);
+        UsernameUtils.setUsernameVars(format("%s %s", cause.getAddr(), cause.getNote()), variables);
         variables.put(BUILD_USER_ID, "remoteTrigger");
         return true;
     }

--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/RemoteCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/RemoteCauseDeterminant.java
@@ -1,0 +1,28 @@
+package org.jenkinsci.plugins.builduser.varsetter.impl;
+
+import java.util.Map;
+
+import org.jenkinsci.plugins.builduser.utils.UsernameUtils;
+import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
+
+import hudson.model.Cause;
+
+public class RemoteCauseDeterminant implements IUsernameSettable<Cause.RemoteCause> {
+
+    @Override
+    public boolean setJenkinsUserBuildVars(Cause.RemoteCause cause, Map<String, String> variables) {
+        if (cause == null) {
+            return false;
+        }
+
+        //As of Jenkins 2.51 remote cause is set the build was triggered using token and real user is not set
+        UsernameUtils.setUsernameVars(cause.getShortDescription(), variables);
+        variables.put(BUILD_USER_ID, "remoteTrigger");
+        return true;
+    }
+
+    @Override
+    public Class<Cause.RemoteCause> getUsedCauseClass() {
+        return Cause.RemoteCause.class;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/RemoteCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/RemoteCauseDeterminant.java
@@ -19,7 +19,7 @@ public class RemoteCauseDeterminant implements IUsernameSettable<Cause.RemoteCau
 
         //As of Jenkins 2.51 remote cause is set the build was triggered using token and real user is not set
         UsernameUtils.setUsernameVars(format("%s %s", cause.getAddr(), cause.getNote()), variables);
-        variables.put(BUILD_USER_ID, "remoteTrigger");
+        variables.put(BUILD_USER_ID, "remoteRequest");
         return true;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/SCMTriggerCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/SCMTriggerCauseDeterminant.java
@@ -16,8 +16,8 @@ public class SCMTriggerCauseDeterminant implements IUsernameSettable<SCMTrigger.
 			Map<String, String> variables) {
 		
         if (cause != null) {
-			UsernameUtils.setUsernameVars("SCMTrigger", variables);
-			variables.put(BUILD_USER_ID, "scmTrigger");
+			UsernameUtils.setUsernameVars("SCM Change", variables);
+			variables.put(BUILD_USER_ID, "scmChange");
 			
 			return true;
 		} else {

--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/SCMTriggerCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/SCMTriggerCauseDeterminant.java
@@ -17,6 +17,7 @@ public class SCMTriggerCauseDeterminant implements IUsernameSettable<SCMTrigger.
 		
         if (cause != null) {
 			UsernameUtils.setUsernameVars("SCMTrigger", variables);
+			variables.put(BUILD_USER_ID, "scmTrigger");
 			
 			return true;
 		} else {

--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/TimerTriggerCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/TimerTriggerCauseDeterminant.java
@@ -9,8 +9,8 @@ import hudson.triggers.TimerTrigger;
 
 public class TimerTriggerCauseDeterminant implements IUsernameSettable<TimerTrigger.TimerTriggerCause> {
 
-    private static final String TIMER_TRIGGER_DUMMY_USER_NAME = "Timer Trigger";
-    private static final String TIMER_TRIGGER_DUMMY_USER_ID = "timerTrigger";
+	private static final String TIMER_TRIGGER_DUMMY_USER_NAME = "Timer Trigger";
+	private static final String TIMER_TRIGGER_DUMMY_USER_ID = "timer";
 
     @Override
 	public boolean setJenkinsUserBuildVars(TimerTrigger.TimerTriggerCause cause, Map<String, String> variables) {

--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/TimerTriggerCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/TimerTriggerCauseDeterminant.java
@@ -1,0 +1,30 @@
+package org.jenkinsci.plugins.builduser.varsetter.impl;
+
+import java.util.Map;
+
+import org.jenkinsci.plugins.builduser.utils.UsernameUtils;
+import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
+
+import hudson.triggers.TimerTrigger;
+
+public class TimerTriggerCauseDeterminant implements IUsernameSettable<TimerTrigger.TimerTriggerCause> {
+
+    private static final String TIMER_TRIGGER_DUMMY_USER_NAME = "Timer Trigger";
+    private static final String TIMER_TRIGGER_DUMMY_USER_ID = "timerTrigger";
+
+    @Override
+	public boolean setJenkinsUserBuildVars(TimerTrigger.TimerTriggerCause cause, Map<String, String> variables) {
+		if (cause == null) {
+			return false;
+		}
+
+		UsernameUtils.setUsernameVars(TIMER_TRIGGER_DUMMY_USER_NAME, variables);
+		variables.put(BUILD_USER_ID, TIMER_TRIGGER_DUMMY_USER_ID);
+		return true;
+	}
+
+	@Override
+	public Class<TimerTrigger.TimerTriggerCause> getUsedCauseClass() {
+		return TimerTrigger.TimerTriggerCause.class;
+	}
+}

--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminant.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.builduser.utils.UsernameUtils;
 import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
+
+import hudson.security.ACL;
 import hudson.tasks.Mailer;
 import hudson.model.User;
 import hudson.model.UserProperty;
@@ -37,8 +39,9 @@ public class UserIdCauseDeterminant implements IUsernameSettable<UserIdCause> {
 		if(null != cause) {
 			String username = cause.getUserName();
 			UsernameUtils.setUsernameVars(username, variables);
-			
-			String userid = StringUtils.trimToEmpty(cause.getUserId());
+
+			String trimmedUserId = StringUtils.trimToEmpty(cause.getUserId());
+			String userid = trimmedUserId.isEmpty() ? ACL.ANONYMOUS_USERNAME : trimmedUserId;
 			variables.put(BUILD_USER_ID, userid);
 			
             		User user=User.get(userid);


### PR DESCRIPTION
 - [JENKINS-29253](https://issues.jenkins-ci.org/browse/JENKINS-29253) Set user if triggered by timer
 - [JENKINS-43090](https://issues.jenkins-ci.org/browse/JENKINS-43090) Set userId for anonymous user
 - [JENKINS-23251](https://issues.jenkins-ci.org/browse/JENKINS-23251) Set dummy user if trigger remotely with token
 - Change check order to better handle manual reruns
 - Set also BUILD_USER_ID in ScmTrigger
 - Log cause(s) if unhandled
