### PR TITLE
Make saml dependency optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>saml</artifactId>
             <version>1.0.4</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,22 +41,6 @@
             <version>2.6</version>
         </dependency>
         <dependency>
-            <groupId>org.pac4j</groupId>
-            <artifactId>pac4j-saml</artifactId>
-            <version>1.9.9</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>net.shibboleth.utilities</groupId>
-                    <artifactId>java-support</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -98,4 +98,29 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>without-optional-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>org.jenkins-ci.plugins:saml</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                            <excludes>
+                                <exclude>**/*Saml*</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/test/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminantSamlTest.java
+++ b/src/test/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminantSamlTest.java
@@ -1,0 +1,74 @@
+package org.jenkinsci.plugins.builduser.varsetter.impl;
+
+import hudson.model.*;
+import hudson.model.Cause.UserIdCause;
+
+import hudson.security.ChainedServletFilter;
+import hudson.security.SecurityRealm;
+import jenkins.model.IdStrategy;
+import org.acegisecurity.GrantedAuthority;
+import org.easymock.EasyMock;
+import org.jenkinsci.plugins.saml.SamlSecurityRealm;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import javax.servlet.FilterConfig;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.easymock.EasyMock.anyObject;
+
+public class UserIdCauseDeterminantSamlTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    public Map<String, String> runSamlSecurityRealmTest(JenkinsRule r, String userid, String caseConversion) {
+        GrantedAuthority[] grantedAuthorities = new GrantedAuthority[0];
+        org.acegisecurity.userdetails.User user =
+                new org.acegisecurity.userdetails.User(
+                        userid,
+                        "password123",
+                        true,
+                        grantedAuthorities);
+        SamlSecurityRealm realm = EasyMock.mock(SamlSecurityRealm.class);
+
+        IdStrategy strategy = new IdStrategy.CaseSensitive();
+        EasyMock.expect(realm.getUserIdStrategy()).andReturn(strategy).anyTimes();
+        EasyMock.expect(realm.getSecurityComponents()).andReturn(new SecurityRealm.SecurityComponents());
+        EasyMock.expect(realm.createFilter(anyObject(FilterConfig.class))).andReturn(new ChainedServletFilter());
+        EasyMock.expect(realm.getUsernameCaseConversion()).andReturn(caseConversion);
+        EasyMock.expect(realm.loadUserByUsername(userid)).andReturn(user).anyTimes();
+
+        EasyMock.replay(realm);
+
+        User.getById(userid, true);
+        r.jenkins.setSecurityRealm(realm);
+        Map<String, String> outputVars = new HashMap<String, String>();
+        UserIdCause cause = new UserIdCause(userid);
+        UserIdCauseDeterminant determinant = new UserIdCauseDeterminant();
+        determinant.setJenkinsUserBuildVars(cause, outputVars);
+        return outputVars;
+    }
+
+    @Test
+    public void testSetJenkinsUserBuildVarsSamlUpperCase() {
+        Map<String, String> outputVars = runSamlSecurityRealmTest(r, "Testuser", "uppercase");
+        assertThat(outputVars.get("BUILD_USER_ID"), is(equalTo("TESTUSER")));
+    }
+
+    @Test
+    public void testSetJenkinsUserBuildVarsSamlLowerCase() {
+        Map<String, String> outputVars = runSamlSecurityRealmTest(r, "Testuser", "lowercase");
+        assertThat(outputVars.get("BUILD_USER_ID"), is(equalTo("testuser")));
+    }
+
+    @Test
+    public void testSetJenkinsUserBuildVarsSamlNoCase() {
+        Map<String, String> outputVars = runSamlSecurityRealmTest(r, "Testuser", "none");
+        assertThat(outputVars.get("BUILD_USER_ID"), is(equalTo("Testuser")));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminantTest.java
+++ b/src/test/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminantTest.java
@@ -3,137 +3,70 @@ package org.jenkinsci.plugins.builduser.varsetter.impl;
 import hudson.model.*;
 import hudson.model.Cause.UserIdCause;
 
-import hudson.security.ChainedServletFilter;
-import hudson.security.SecurityRealm;
-import jenkins.model.IdStrategy;
-import org.acegisecurity.GrantedAuthority;
-import org.easymock.EasyMock;
-import org.jenkinsci.plugins.saml.SamlSecurityRealm;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
 
-import javax.servlet.FilterConfig;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.easymock.EasyMock.anyObject;
 
 public class UserIdCauseDeterminantTest {
 
     @Rule
-    public RestartableJenkinsRule rr = new RestartableJenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
 
     @Test
     public void testSetJenkinsUserBuildVars() throws Exception {
-        rr.then(r-> {
-            User.getById("testuser", true);
-            JenkinsRule.DummySecurityRealm realm = r.createDummySecurityRealm();
-            r.jenkins.setSecurityRealm(realm);
-            realm.addGroups("testuser", "group1", "group2");
-            Map<String, String> outputVars = new HashMap<String, String>();
-            UserIdCause cause = new UserIdCause("testuser");
-            UserIdCauseDeterminant determinant = new UserIdCauseDeterminant();
-            determinant.setJenkinsUserBuildVars(cause, outputVars);
-            System.out.println(outputVars);
-            assert(outputVars.get("BUILD_USER_GROUPS").equals("authenticated,group1,group2"));
-        });
+        User.getById("testuser", true);
+        JenkinsRule.DummySecurityRealm realm = r.createDummySecurityRealm();
+        r.jenkins.setSecurityRealm(realm);
+        realm.addGroups("testuser", "group1", "group2");
+        Map<String, String> outputVars = new HashMap<String, String>();
+        UserIdCause cause = new UserIdCause("testuser");
+        UserIdCauseDeterminant determinant = new UserIdCauseDeterminant();
+        determinant.setJenkinsUserBuildVars(cause, outputVars);
+        System.out.println(outputVars);
+        assertThat(outputVars.get("BUILD_USER_GROUPS"), is(equalTo("authenticated,group1,group2")));
     }
 
     @Test
     public void testSetJenkinsUserBuildVarsInvalidUser() {
-        rr.then(r-> {
-            JenkinsRule.DummySecurityRealm realm = r.createDummySecurityRealm();
-            r.jenkins.setSecurityRealm(realm);
-            Map<String, String> outputVars = new HashMap<String, String>();
-            UserIdCause cause = new UserIdCause("testuser");
-            UserIdCauseDeterminant determinant = new UserIdCauseDeterminant();
-            determinant.setJenkinsUserBuildVars(cause, outputVars);
-            System.out.println(outputVars);
-            // 'anonymous' user gets authenticated group automatically
-            assert(outputVars.get("BUILD_USER_GROUPS").equals("authenticated"));
-        });
+        JenkinsRule.DummySecurityRealm realm = r.createDummySecurityRealm();
+        r.jenkins.setSecurityRealm(realm);
+        Map<String, String> outputVars = new HashMap<String, String>();
+        UserIdCause cause = new UserIdCause("testuser");
+        UserIdCauseDeterminant determinant = new UserIdCauseDeterminant();
+        determinant.setJenkinsUserBuildVars(cause, outputVars);
+        System.out.println(outputVars);
+        // 'anonymous' user gets authenticated group automatically
+        assertThat(outputVars.get("BUILD_USER_GROUPS"), is(equalTo("authenticated")));
     }
 
     @Test
     public void testSetJenkinsUserBuildVarsNoGroups() {
-        rr.then(r-> {
-            User.getById("testuser", true);
-            JenkinsRule.DummySecurityRealm realm = r.createDummySecurityRealm();
-            r.jenkins.setSecurityRealm(realm);
-            Map<String, String> outputVars = new HashMap<String, String>();
-            UserIdCause cause = new UserIdCause("testuser");
-            UserIdCauseDeterminant determinant = new UserIdCauseDeterminant();
-            determinant.setJenkinsUserBuildVars(cause, outputVars);
-            System.out.println(outputVars);
-            // User still gets authenticated group automatically
-            assert(outputVars.get("BUILD_USER_GROUPS").equals("authenticated"));
-        });
+        User.getById("testuser", true);
+        JenkinsRule.DummySecurityRealm realm = r.createDummySecurityRealm();
+        r.jenkins.setSecurityRealm(realm);
+        Map<String, String> outputVars = new HashMap<String, String>();
+        UserIdCause cause = new UserIdCause("testuser");
+        UserIdCauseDeterminant determinant = new UserIdCauseDeterminant();
+        determinant.setJenkinsUserBuildVars(cause, outputVars);
+        System.out.println(outputVars);
+        // User still gets authenticated group automatically
+        assertThat(outputVars.get("BUILD_USER_GROUPS"), is(equalTo("authenticated")));
     }
 
     @Test
     public void testSetJenkinsUserBuildVarsNoSecurityRealm() throws Exception {
-        rr.then(r-> {
-            User.getById("testuser", true);
-            Map<String, String> outputVars = new HashMap<String, String>();
-            UserIdCause cause = new UserIdCause("testuser");
-            UserIdCauseDeterminant determinant = new UserIdCauseDeterminant();
-            determinant.setJenkinsUserBuildVars(cause, outputVars);
-            System.out.println(outputVars);
-            assert(outputVars.get("BUILD_USER_GROUPS").equals(""));
-        });
-    }
-
-    public Map<String, String> runSamlSecurityRealmTest(JenkinsRule r, String userid, String caseConversion) {
-        GrantedAuthority[] grantedAuthorities = new GrantedAuthority[0];
-        org.acegisecurity.userdetails.User user =
-                new org.acegisecurity.userdetails.User(
-                        userid,
-                        "password123",
-                        true,
-                        grantedAuthorities);
-        SamlSecurityRealm realm = EasyMock.mock(SamlSecurityRealm.class);
-
-        IdStrategy strategy = new IdStrategy.CaseSensitive();
-        EasyMock.expect(realm.getUserIdStrategy()).andReturn(strategy).anyTimes();
-        EasyMock.expect(realm.getSecurityComponents()).andReturn(new SecurityRealm.SecurityComponents());
-        EasyMock.expect(realm.createFilter(anyObject(FilterConfig.class))).andReturn(new ChainedServletFilter());
-        EasyMock.expect(realm.getUsernameCaseConversion()).andReturn(caseConversion);
-        EasyMock.expect(realm.loadUserByUsername(userid)).andReturn(user).anyTimes();
-
-        EasyMock.replay(realm);
-
-        User.getById(userid, true);
-        r.jenkins.setSecurityRealm(realm);
+        User.getById("testuser", true);
         Map<String, String> outputVars = new HashMap<String, String>();
-        UserIdCause cause = new UserIdCause(userid);
+        UserIdCause cause = new UserIdCause("testuser");
         UserIdCauseDeterminant determinant = new UserIdCauseDeterminant();
         determinant.setJenkinsUserBuildVars(cause, outputVars);
-        return outputVars;
-    }
-
-    @Test
-    public void testSetJenkinsUserBuildVarsSamlUpperCase() {
-        rr.then(r-> {
-            Map<String, String> outputVars = runSamlSecurityRealmTest(r, "Testuser", "uppercase");
-            assert(outputVars.get("BUILD_USER_ID").equals("TESTUSER"));
-        });
-    }
-
-    @Test
-    public void testSetJenkinsUserBuildVarsSamlLowerCase() {
-        rr.then(r-> {
-            Map<String, String> outputVars = runSamlSecurityRealmTest(r, "Testuser", "lowercase");
-            assert(outputVars.get("BUILD_USER_ID").equals("testuser"));
-        });
-    }
-
-    @Test
-    public void testSetJenkinsUserBuildVarsSamlNoCase() {
-        rr.then(r-> {
-            Map<String, String> outputVars = runSamlSecurityRealmTest(r, "Testuser", "none");
-            assert(outputVars.get("BUILD_USER_ID").equals("Testuser"));
-        });
+        System.out.println(outputVars);
+        assertThat(outputVars.get("BUILD_USER_GROUPS"), is(equalTo("")));
     }
 }


### PR DESCRIPTION
This spares user not using the saml plugin from installing it, by handling the expected classloading error. (see also https://github.com/jenkinsci/build-user-vars-plugin/pull/19#issuecomment-778077759 and https://www.jenkins.io/doc/developer/plugin-development/optional-dependencies/)

Tests are adapted to test both cases: With and without installed saml plugin.

PS: I noticed this uses acegisecurity internals, which might break for newer Jenkins versions (> 2.226, because of JEP-227), see https://www.jenkins.io/blog/2020/11/10/spring-xstream/ for details