### PR TITLE
Global option to add build user variables to the environment for all builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ The plugin provides the following environment variables:
 | BUILD\_USER\_GROUPS      | Jenkins user groups                |
 | BUILD\_USER\_EMAIL       | Email address                      |
 
+## Since 1.8
+
+Set the global option to add build user variables to the environment for all builds (in **Manage Jenkins, Configure System**).
+
 ## Usage example
 
 Select *Set Jenkins user build variables* and reference the variables during the build:

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.50</version>
+        <version>4.24</version>
     </parent>
 
     <artifactId>build-user-vars-plugin</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
@@ -31,6 +31,8 @@ import org.jenkinsci.plugins.builduser.varsetter.impl.SCMTriggerCauseDeterminant
 import org.jenkinsci.plugins.builduser.varsetter.impl.TimerTriggerCauseDeterminant;
 import org.jenkinsci.plugins.builduser.varsetter.impl.UserCauseDeterminant;
 import org.jenkinsci.plugins.builduser.varsetter.impl.UserIdCauseDeterminant;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -65,7 +67,8 @@ public class BuildUser extends SimpleBuildWrapper {
      * <p>
      * TODO: The whole hierarchy and way of applying could be refactored.
      */
-    private void makeUserBuildVariables(@Nonnull Run<?, ?> build, @Nonnull Map<String, String> variables) {
+    @Restricted(NoExternalUse.class)
+    static void makeUserBuildVariables(@Nonnull Run<?, ?> build, @Nonnull Map<String, String> variables) {
 
         /* Try to use UserIdCause to get & set jenkins user build variables */
         UserIdCause userIdCause = build.getCause(UserIdCause.class);
@@ -98,7 +101,7 @@ public class BuildUser extends SimpleBuildWrapper {
         handleOtherCausesOrLogWarningIfUnhandled(build, variables);
     }
 
-    private void handleOtherCausesOrLogWarningIfUnhandled(@Nonnull Run<?, ?> build, @Nonnull Map<String, String> variables) {
+    private static void handleOtherCausesOrLogWarningIfUnhandled(@Nonnull Run<?, ?> build, @Nonnull Map<String, String> variables) {
         // set BUILD_USER_NAME and ID to fixed value if the build was triggered by a change in the scm, timer or remotely with token
         SCMTriggerCause scmTriggerCause = build.getCause(SCMTriggerCause.class);
         if (new SCMTriggerCauseDeterminant().setJenkinsUserBuildVars(scmTriggerCause, variables)) {

--- a/src/main/java/org/jenkinsci/plugins/builduser/BuildUserVarsConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/BuildUserVarsConfig.java
@@ -1,0 +1,37 @@
+package org.jenkinsci.plugins.builduser;
+
+import hudson.Extension;
+import hudson.ExtensionList;
+
+import jenkins.model.GlobalConfiguration;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundSetter;
+
+@Extension
+@Symbol("buildUserVars")
+public class BuildUserVarsConfig extends GlobalConfiguration {
+
+    /** @return the singleton instance */
+    public static BuildUserVarsConfig get() {
+        return ExtensionList.lookupSingleton(BuildUserVarsConfig.class);
+    }
+
+    /** Whether to activate {@link BuildUserVarsEnvironmentContributor}. */
+    private boolean allBuilds;
+
+    public BuildUserVarsConfig() {
+        // When Jenkins is restarted, load any saved configuration from disk.
+        load();
+    }
+
+    public boolean isAllBuilds() {
+        return allBuilds;
+    }
+
+    @DataBoundSetter
+    public void setAllBuilds(boolean allBuilds) {
+        this.allBuilds = allBuilds;
+        save();
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/builduser/BuildUserVarsEnvironmentContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/BuildUserVarsEnvironmentContributor.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.plugins.builduser;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.EnvironmentContributor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+@Extension
+public class BuildUserVarsEnvironmentContributor extends EnvironmentContributor {
+
+    @Override
+    public void buildEnvironmentFor(
+            @NonNull Run r, @NonNull EnvVars envs, @NonNull TaskListener listener) {
+        if (BuildUserVarsConfig.get().isAllBuilds()) {
+            BuildUser.makeUserBuildVariables(r, envs);
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/builduser/BuildUserVarsConfig/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/builduser/BuildUserVarsConfig/config.jelly
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:section title="${%Build User Variables}">
+        <f:entry field="allBuilds">
+            <f:checkbox title="${%Enabled for all builds}"/>
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/builduser/BuildUserVarsConfig/help-allBuilds.html
+++ b/src/main/resources/org/jenkinsci/plugins/builduser/BuildUserVarsConfig/help-allBuilds.html
@@ -1,0 +1,4 @@
+<div>
+    When checked, build user variables will be added to the environment for all builds.
+    There is no need to use the <b>Set Jenkins user build variables</b> wrapper.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/builduser/BuildUserVarsConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/builduser/BuildUserVarsConfigTest.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.builduser;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.gargoylesoftware.htmlunit.html.HtmlCheckBoxInput;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsSessionRule;
+
+public class BuildUserVarsConfigTest {
+
+    @Rule public JenkinsSessionRule sessions = new JenkinsSessionRule();
+
+    /**
+     * Tries to exercise enough code paths to catch common mistakes:
+     *
+     * <ul>
+     *   <li>missing {@code load}
+     *   <li>missing {@code save}
+     *   <li>misnamed or absent getter/setter
+     *   <li>misnamed {@code textbox}
+     * </ul>
+     */
+    @Test
+    public void uiAndStorage() throws Throwable {
+        sessions.then(
+                r -> {
+                    assertFalse("not set initially", BuildUserVarsConfig.get().isAllBuilds());
+                    HtmlForm config = r.createWebClient().goTo("configure").getFormByName("config");
+                    HtmlCheckBoxInput checkbox = config.getInputByName("_.allBuilds");
+                    checkbox.setChecked(true);
+                    r.submit(config);
+                    assertTrue(
+                            "global config page let us edit it",
+                            BuildUserVarsConfig.get().isAllBuilds());
+                });
+        sessions.then(
+                r -> {
+                    assertTrue(
+                            "still there after restart of Jenkins",
+                            BuildUserVarsConfig.get().isAllBuilds());
+                });
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/builduser/BuildUserVarsIntegrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/builduser/BuildUserVarsIntegrationTest.java
@@ -1,0 +1,69 @@
+package org.jenkinsci.plugins.builduser;
+
+import static org.junit.Assert.assertEquals;
+
+import hudson.EnvVars;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.FreeStyleProject;
+import hudson.model.User;
+import hudson.tasks.Mailer;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class BuildUserVarsIntegrationTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void smokes() throws Exception {
+        User user = User.getById("bob", true);
+        user.setFullName("Bob Smith");
+        user.addProperty(new Mailer.UserProperty("bob@example.com"));
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+
+        FreeStyleProject p = r.createFreeStyleProject();
+        p.getBuildWrappersList().add(new BuildUser());
+        CaptureEnvironmentBuilder captureEnvironment = new CaptureEnvironmentBuilder();
+        p.getBuildersList().add(captureEnvironment);
+        r.assertBuildStatusSuccess(
+                p.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause(user.getId()))));
+
+        EnvVars envVars = captureEnvironment.getEnvVars();
+        assertEquals("Bob Smith", envVars.get("BUILD_USER"));
+        assertEquals("authenticated", envVars.get("BUILD_USER_GROUPS"));
+        assertEquals("Bob", envVars.get("BUILD_USER_FIRST_NAME"));
+        assertEquals("Smith", envVars.get("BUILD_USER_LAST_NAME"));
+        assertEquals("bob@example.com", envVars.get("BUILD_USER_EMAIL"));
+        assertEquals("bob", envVars.get("BUILD_USER_ID"));
+    }
+
+    @Test
+    public void allBuilds() throws Exception {
+        BuildUserVarsConfig config = BuildUserVarsConfig.get();
+        config.setAllBuilds(true);
+        config.save();
+
+        User user = User.getById("bob", true);
+        user.setFullName("Bob Smith");
+        user.addProperty(new Mailer.UserProperty("bob@example.com"));
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+
+        FreeStyleProject p = r.createFreeStyleProject();
+        CaptureEnvironmentBuilder captureEnvironment = new CaptureEnvironmentBuilder();
+        p.getBuildersList().add(captureEnvironment);
+        r.assertBuildStatusSuccess(
+                p.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause(user.getId()))));
+
+        EnvVars envVars = captureEnvironment.getEnvVars();
+        assertEquals("Bob Smith", envVars.get("BUILD_USER"));
+        assertEquals("authenticated", envVars.get("BUILD_USER_GROUPS"));
+        assertEquals("Bob", envVars.get("BUILD_USER_FIRST_NAME"));
+        assertEquals("Smith", envVars.get("BUILD_USER_LAST_NAME"));
+        assertEquals("bob@example.com", envVars.get("BUILD_USER_EMAIL"));
+        assertEquals("bob", envVars.get("BUILD_USER_ID"));
+    }
+}


### PR DESCRIPTION
Implements @jglick's suggestion from [#15 (comment)](https://github.com/jenkinsci/build-user-vars-plugin/pull/15#issuecomment-779416316) to define an `EnvironmentContributor`. This is disabled by default for backward compatibility but can be enabled for all builds on the *Configure System* page by clicking on a new *Enabled for all builds* checkbox. With the checkbox enabled, build user variables are added to the environment for all builds. This makes this plugin much easier to use from Pipeline jobs, since you no longer need to allocate a node/workspace. CC @fabiodcasilva