### PR TITLE
Deprecated User.get() replaced and clean-up

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminant.java
@@ -12,7 +12,6 @@ import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
 import hudson.security.ACL;
 import hudson.tasks.Mailer;
 import hudson.model.User;
-import hudson.model.UserProperty;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.acegisecurity.GrantedAuthority;
@@ -57,8 +56,8 @@ public class UserIdCauseDeterminant implements IUsernameSettable<UserIdCause> {
 				SecurityRealm realm = jenkinsInstance.getSecurityRealm();
 				userid = mapUserId (userid, realm);
 				GrantedAuthority[] authorities = realm.loadUserByUsername(originalUserid).getAuthorities();
-				for (int i = 0; i < authorities.length; i++) {
-					String authorityString = authorities[i].getAuthority();
+				for (GrantedAuthority authority : authorities) {
+					String authorityString = authority.getAuthority();
 					if (authorityString != null && authorityString.length() > 0) {
 						groupString.append(authorityString).append(",");
 					}
@@ -66,7 +65,7 @@ public class UserIdCauseDeterminant implements IUsernameSettable<UserIdCause> {
 				groupString.setLength(groupString.length() == 0 ? 0 : groupString.length() - 1);
 			} catch (Exception err) {
 				// Error
-				log.warning(String.format("Failed to get groups for user: %s error: %s ", userid, err.toString()));
+				log.warning(String.format("Failed to get groups for user: %s error: %s ", userid, err));
 			}
 			variables.put(BUILD_USER_ID, userid);
 			variables.put(BUILD_USER_VAR_GROUPS, groupString.toString());
@@ -74,9 +73,9 @@ public class UserIdCauseDeterminant implements IUsernameSettable<UserIdCause> {
 
 			User user=User.get(originalUserid);
             		if(null != user) {
-            		    UserProperty prop = user.getProperty(Mailer.UserProperty.class);
+            		    Mailer.UserProperty prop = user.getProperty(Mailer.UserProperty.class);
             		    if(null != prop) {
-            		        String adrs = StringUtils.trimToEmpty(((Mailer.UserProperty)prop).getAddress());
+            		        String adrs = StringUtils.trimToEmpty(prop.getAddress());
             		        variables.put(BUILD_USER_EMAIL, adrs);
             		    }
             		}

--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminant.java
@@ -71,14 +71,14 @@ public class UserIdCauseDeterminant implements IUsernameSettable<UserIdCause> {
 			variables.put(BUILD_USER_VAR_GROUPS, groupString.toString());
 
 
-			User user=User.get(originalUserid);
-            		if(null != user) {
-            		    Mailer.UserProperty prop = user.getProperty(Mailer.UserProperty.class);
-            		    if(null != prop) {
-            		        String adrs = StringUtils.trimToEmpty(prop.getAddress());
-            		        variables.put(BUILD_USER_EMAIL, adrs);
-            		    }
-            		}
+			User user = User.getById(originalUserid, false);
+			if (null != user) {
+				Mailer.UserProperty prop = user.getProperty(Mailer.UserProperty.class);
+				if (null != prop) {
+					String adrs = StringUtils.trimToEmpty(prop.getAddress());
+					variables.put(BUILD_USER_EMAIL, adrs);
+				}
+			}
 
 			return true;
 		} else {

--- a/src/test/java/org/jenkinsci/plugins/builduser/BuildUserTest.java
+++ b/src/test/java/org/jenkinsci/plugins/builduser/BuildUserTest.java
@@ -78,8 +78,7 @@ public class BuildUserTest {
         // Register non-existent build as an execution cause
         Build<FreeStyleProject, FreeStyleBuild> downstreamBuild = childProject.getLastBuild();
         List<CauseAction> actions = downstreamBuild.getActions(CauseAction.class);
-        Assert.assertTrue("CauseAction has not been created properly",
-                actions != null && actions.size() == 1);
+        Assert.assertEquals("CauseAction has not been created properly", 1, actions.size());
         Cause.UpstreamCause upstreamCause = null;
         List<Cause> causes = actions.get(0).getCauses();
         for (Cause cause : causes) {

--- a/src/test/java/org/jenkinsci/plugins/builduser/BuildUserVarsConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/builduser/BuildUserVarsConfigTest.java
@@ -38,10 +38,8 @@ public class BuildUserVarsConfigTest {
                             BuildUserVarsConfig.get().isAllBuilds());
                 });
         sessions.then(
-                r -> {
-                    assertTrue(
-                            "still there after restart of Jenkins",
-                            BuildUserVarsConfig.get().isAllBuilds());
-                });
+                r -> assertTrue(
+                        "still there after restart of Jenkins",
+                        BuildUserVarsConfig.get().isAllBuilds()));
     }
 }


### PR DESCRIPTION
Replaces the deprecated `User.get()` with `User.getById()` and some code clean-up.

---------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
