### PR TITLE
Do not flood the logs with branch-api causes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
             <version>1.0.4</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>branch-api</artifactId>
+            <version>2.6.0</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import jenkins.branch.BranchEventCause;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildWrapper;
 
@@ -116,6 +117,16 @@ public class BuildUser extends SimpleBuildWrapper {
         RemoteCause remoteTriggerCause = build.getCause(RemoteCause.class);
         if (new RemoteCauseDeterminant().setJenkinsUserBuildVars(remoteTriggerCause, variables)) {
             return;
+        }
+
+        try {
+            BranchEventCause branchEventCause = build.getCause(BranchEventCause.class);
+            if (branchEventCause != null) {
+                // branch event cause does not have to be logged.
+                return;
+            }
+        } catch (NoClassDefFoundError e) {
+            log.fine("It seems the branch-api plugin is not installed, skipping.");
         }
 
         log.warning(() -> "Unsupported cause type(s): " + Arrays.toString(build.getCauses().toArray()));


### PR DESCRIPTION
Since we are using the branch-api plugin together with GitHub our log is flooded with lines like this:

> Unsupported cause type(s): [jenkins.branch.BranchEventCause@5ca9b86c]
> Feb 03, 2022 9:35:13 AM WARNING org.jenkinsci.plugins.builduser.BuildUser handleOtherCausesOrLogWarningIfUnhandled

Since this cause is never triggerd by a user, I just want to ignore it.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
