### PR TITLE
BranchIndexingTrigger support

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
@@ -23,10 +23,12 @@ import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import jenkins.branch.BranchEventCause;
+import jenkins.branch.BranchIndexingCause;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildWrapper;
 
 import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
+import org.jenkinsci.plugins.builduser.varsetter.impl.BranchIndexingTriggerDeterminant;
 import org.jenkinsci.plugins.builduser.varsetter.impl.RemoteCauseDeterminant;
 import org.jenkinsci.plugins.builduser.varsetter.impl.SCMTriggerCauseDeterminant;
 import org.jenkinsci.plugins.builduser.varsetter.impl.TimerTriggerCauseDeterminant;
@@ -120,6 +122,11 @@ public class BuildUser extends SimpleBuildWrapper {
         }
 
         try {
+            BranchIndexingCause branchIndexingCause = build.getCause(BranchIndexingCause.class);
+            if (new BranchIndexingTriggerDeterminant().setJenkinsUserBuildVars(branchIndexingCause, variables)) {
+                return;
+            }
+
             BranchEventCause branchEventCause = build.getCause(BranchEventCause.class);
             if (branchEventCause != null) {
                 // branch event cause does not have to be logged.

--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/BranchIndexingTriggerDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/BranchIndexingTriggerDeterminant.java
@@ -1,0 +1,26 @@
+package org.jenkinsci.plugins.builduser.varsetter.impl;
+
+import jenkins.branch.BranchIndexingCause;
+import org.jenkinsci.plugins.builduser.utils.UsernameUtils;
+import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
+
+import java.util.Map;
+
+public class BranchIndexingTriggerDeterminant implements IUsernameSettable<BranchIndexingCause> {
+    private static final Class<BranchIndexingCause> causeClass = BranchIndexingCause.class;
+
+    @Override
+    public boolean setJenkinsUserBuildVars(BranchIndexingCause cause, Map<String, String> variables) {
+        if (cause != null) {
+            UsernameUtils.setUsernameVars("Branch Indexing", variables);
+            variables.put(BUILD_USER_ID, "branchIndexing");
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Class<BranchIndexingCause> getUsedCauseClass() {
+        return causeClass;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/builduser/varsetter/impl/BranchIndexingTriggerDeterminantTest.java
+++ b/src/test/java/org/jenkinsci/plugins/builduser/varsetter/impl/BranchIndexingTriggerDeterminantTest.java
@@ -1,0 +1,49 @@
+package org.jenkinsci.plugins.builduser.varsetter.impl;
+
+import jenkins.branch.BranchIndexingCause;
+import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BranchIndexingTriggerDeterminantTest {
+    @Test
+    public void usedCauseClassIsBranchIndexingCause() {
+        assertThat(new BranchIndexingTriggerDeterminant().getUsedCauseClass(), equalTo(BranchIndexingCause.class));
+    }
+
+    @Test
+    public void setVarsReturnsFalseWithoutBuildUserVarsOnNullCause() {
+        Map<String, String> variables = new HashMap<>();
+        assertFalse(new BranchIndexingTriggerDeterminant().setJenkinsUserBuildVars(null, variables));
+        assertThat(variables, equalTo(Collections.emptyMap()));
+    }
+
+    @Test
+    public void setVarsReturnsTrueWithBuildUsersVarsOnValidCause() throws Exception {
+        Map<String, String> variables = new HashMap<>();
+        assertTrue(new BranchIndexingTriggerDeterminant().setJenkinsUserBuildVars(mockCause(), variables));
+        assertThat(variables, allOf(hasEntry(IUsernameSettable.BUILD_USER_VAR_NAME, "Branch Indexing"),
+                hasEntry(IUsernameSettable.BUILD_USER_FIRST_NAME_VAR_NAME, "Branch"),
+                hasEntry(IUsernameSettable.BUILD_USER_LAST_NAME_VAR_NAME, "Indexing"),
+                hasEntry(IUsernameSettable.BUILD_USER_ID, "branchIndexing")
+        ));
+    }
+
+    private BranchIndexingCause mockCause() throws Exception {
+        Constructor<BranchIndexingCause> ctor = BranchIndexingCause.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        return ctor.newInstance();
+    }
+
+}


### PR DESCRIPTION
Support _BranchIndexingTrigger_ and set values accordingly. 

Builds triggered by Branch Indexing log an "unspported cause type(s)" warning currently.

As `BranchEventCause`, `BranchIndexingCause` is only relevant if the optional _branch-api_ plugin is present.


-----------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
