### PR TITLE
Require Java 17 and 2.475; adapt test suite to EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,16 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.440.x</artifactId>
+                <artifactId>bom-2.462.x</artifactId>
                 <version>3307.v2769886db_63b_</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <!-- TODO JENKINS-73339 until in parent POM, work around https://github.com/jenkinsci/plugin-pom/issues/936 -->
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>5.0.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -69,7 +75,10 @@
 
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.440.3</jenkins.version>
+        <jenkins.version>2.475</jenkins.version>
+        <!-- TODO JENKINS-73339 until in parent POM -->
+        <jenkins-test-harness.version>2265.v3da_49c8134d6</jenkins-test-harness.version>
+        <maven.compiler.release>17</maven.compiler.release>
         <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
     </properties>
 

--- a/src/test/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminantSamlTest.java
+++ b/src/test/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminantSamlTest.java
@@ -13,7 +13,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 
-import javax.servlet.FilterConfig;
+import jakarta.servlet.FilterConfig;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION
Allow this plugin's test suite to be exercised regularly in Plugin Compatibility Tester (PCT) in https://github.com/jenkinsci/bom by requiring Java 17 or newer and Jenkins 2.475 (released today) or newer.

This PR goes against the usual advice from https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ by requiring a weekly release. The advantage is that this will allow plugin compatibility testing (PCT). The disadvantage is that new features and bug fixes can't be released to LTS users for another few months.

The choice is up to the maintainer as to whether or not to accept this PR. If this PR is rejected, we will stop testing this plugin in PCT.