### PR TITLE
Add missing symbol on descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,17 @@ Select *Set Jenkins user build variables* and reference the variables during the
 
 ```groovy
 node {
-  wrap([$class: 'BuildUser']) {
+  withBuildUser {
     def user = env.BUILD_USER_ID
   }
+}
+```
+
+or with declarative option:
+  
+```groovy
+options {
+  withBuildUser()
 }
 ```
 

--- a/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
@@ -20,6 +20,7 @@ import jenkins.branch.BranchEventCause;
 import jenkins.branch.BranchIndexingCause;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildWrapper;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
 import org.jenkinsci.plugins.builduser.varsetter.impl.*;
 import org.kohsuke.accmod.Restricted;
@@ -134,6 +135,7 @@ public class BuildUser extends SimpleBuildWrapper {
     }
 
     @Extension
+    @Symbol("withBuildUser")
     public static class DescriptorImpl extends BuildWrapperDescriptor {
         @Override
         public boolean isApplicable(AbstractProject<?, ?> item) {


### PR DESCRIPTION
Allow to use symbol directly instead of wrap step

+ update doc

### Testing done

None, not pipeline test for this plugin.

But I suppose the Symbol is working like any other build wrapper

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
