### PR TITLE
[JENKINS-25083] use MailAddressResolver for retrieving user email instead of UserProperty

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminant.java
@@ -4,7 +4,7 @@ import hudson.model.Cause.UserIdCause;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.SecurityRealm;
-import hudson.tasks.Mailer.UserProperty;
+import hudson.tasks.MailAddressResolver;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.builduser.utils.BuildUserVariable;
@@ -90,10 +90,8 @@ public class UserIdCauseDeterminant implements IUsernameSettable<UserIdCause> {
 
 	private void setUserEmail(String userId, Map<String, String> variables) {
 		Optional.ofNullable(User.getById(userId, false))
-				.map(user -> user.getProperty(UserProperty.class))
-				.map(UserProperty::getAddress)
-				.map(StringUtils::trimToEmpty)
-				.ifPresent(address -> variables.put(BuildUserVariable.EMAIL, address));
+				.map(MailAddressResolver::resolve)
+				.ifPresent(email -> variables.put(BuildUserVariable.EMAIL, email));
 	}
 
 	/**

--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminant.java
@@ -11,10 +11,8 @@ import org.jenkinsci.plugins.builduser.utils.BuildUserVariable;
 import org.jenkinsci.plugins.builduser.utils.UsernameUtils;
 import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
 import org.jenkinsci.plugins.saml.SamlSecurityRealm;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Logger;
@@ -73,7 +71,6 @@ public class UserIdCauseDeterminant implements IUsernameSettable<UserIdCause> {
 
     private void setUserGroups(String userId, Map<String, String> variables) {
         try {
-            SecurityRealm realm = Jenkins.get().getSecurityRealm();
             Optional.ofNullable(User.getById(userId, false))
                     .map(User::impersonate2)
                     .map(authentication -> authentication.getAuthorities().stream()

--- a/src/test/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminantEmailTest.java
+++ b/src/test/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminantEmailTest.java
@@ -1,0 +1,51 @@
+package org.jenkinsci.plugins.builduser.varsetter.impl;
+
+import hudson.model.Cause.UserIdCause;
+import hudson.model.User;
+import hudson.tasks.MailAddressResolver;
+import hudson.tasks.Mailer.UserProperty;
+import org.jenkinsci.plugins.builduser.utils.BuildUserVariable;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class UserIdCauseDeterminantEmailTest {
+    public static final String TEST_USER = "test_user";
+    
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void testSetJenkinsUserBuildVarsEmailWithResolver() throws IOException {
+        User user = User.getById(TEST_USER, true);
+        assert user != null;
+        user.addProperty(new UserProperty(null));
+
+        JenkinsRule.DummySecurityRealm realm = r.createDummySecurityRealm();
+        r.jenkins.setSecurityRealm(realm);
+
+        Map<String, String> outputVars = new HashMap<>();
+        UserIdCause cause = new UserIdCause(TEST_USER);
+        UserIdCauseDeterminant determinant = new UserIdCauseDeterminant();
+        determinant.setJenkinsUserBuildVars(cause, outputVars);
+
+        assertThat(outputVars.get(BuildUserVariable.EMAIL), is(equalTo("resolveduser@example.com")));
+    }
+
+    @TestExtension
+    public static class TestMailAddressResolver extends MailAddressResolver {
+        @Override
+        public String findMailAddressFor(User user) {
+            return "resolveduser@example.com";
+        }
+    }
+}


### PR DESCRIPTION
This pull request addresses [build-user-vars-plugin] - Improper resolution of user e-mails](https://issues.jenkins.io/browse/JENKINS-25083)

Follow-up to: [Commit 3ff2b523e9663b485ed0cbdb3ab129b64bd5e179](https://github.com/jenkinsci/build-user-vars-plugin/commit/3ff2b523e9663b485ed0cbdb3ab129b64bd5e179)

The previous implementation for resolving user email addresses directly utilized UserProperty, which was identified as an improper method for this task. Instead, MailAddressResolver should be used which is specifically designed for inferring email addresses.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue