### PR TITLE
JENKINS-73420: Fix compatibility with SecurityRealms the do not support querying information

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminant.java
@@ -11,6 +11,7 @@ import org.jenkinsci.plugins.builduser.utils.BuildUserVariable;
 import org.jenkinsci.plugins.builduser.utils.UsernameUtils;
 import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
 import org.jenkinsci.plugins.saml.SamlSecurityRealm;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 
 import java.util.Collection;
@@ -26,14 +27,14 @@ import java.util.stream.Collectors;
  */
 public class UserIdCauseDeterminant implements IUsernameSettable<UserIdCause> {
 
-	private static final Logger log = Logger.getLogger(UserIdCauseDeterminant.class.getName());
+    private static final Logger log = Logger.getLogger(UserIdCauseDeterminant.class.getName());
 
-	/**
-	 * {@inheritDoc}
-	 * <p>
-	 * <b>{@link UserIdCause}</b> based implementation.
-	 */
-	public boolean setJenkinsUserBuildVars(UserIdCause cause, Map<String, String> variables) {
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <b>{@link UserIdCause}</b> based implementation.
+     */
+    public boolean setJenkinsUserBuildVars(UserIdCause cause, Map<String, String> variables) {
         if (cause == null) {
             return false;
         }
@@ -47,59 +48,60 @@ public class UserIdCauseDeterminant implements IUsernameSettable<UserIdCause> {
 
         variables.put(BuildUserVariable.ID, userid);
 
-		setUserGroups(originalUserId, variables);
-		setUserEmail(originalUserId, variables);
+        setUserGroups(originalUserId, variables);
+        setUserEmail(originalUserId, variables);
 
         return true;
     }
 
-	private String mapUserId(String userId) {
-		try {
-			SecurityRealm realm = Jenkins.get().getSecurityRealm();
-			if (realm instanceof SamlSecurityRealm samlSecurityRealm) {
-				String conversion = samlSecurityRealm.getUsernameCaseConversion();
+    private String mapUserId(String userId) {
+        try {
+            SecurityRealm realm = Jenkins.get().getSecurityRealm();
+            if (realm instanceof SamlSecurityRealm samlSecurityRealm) {
+                String conversion = samlSecurityRealm.getUsernameCaseConversion();
                 return switch (conversion) {
                     case "lowercase" -> userId.toLowerCase();
                     case "uppercase" -> userId.toUpperCase();
                     default -> userId;
                 };
-			}
-		} catch (NoClassDefFoundError e) {
-			log.fine("It seems the saml plugin is not installed, skipping saml user name mapping.");
-		}
-		return userId;
-	}
+            }
+        } catch (NoClassDefFoundError e) {
+            log.fine("It seems the saml plugin is not installed, skipping saml user name mapping.");
+        }
+        return userId;
+    }
 
-	private void setUserGroups(String userId, Map<String, String> variables) {
-		try {
-			SecurityRealm realm = Jenkins.get().getSecurityRealm();
-			Collection<? extends GrantedAuthority> authorities = realm.loadUserByUsername2(userId).getAuthorities();
+    private void setUserGroups(String userId, Map<String, String> variables) {
+        try {
+            SecurityRealm realm = Jenkins.get().getSecurityRealm();
+            Optional.ofNullable(User.getById(userId, false))
+                    .map(User::impersonate2)
+                    .map(authentication -> authentication.getAuthorities().stream()
+                                    .map(GrantedAuthority::getAuthority)
+                                    .filter(authority -> authority != null && !authority.isEmpty())
+                                    .collect(Collectors.joining(","))
+                    ).ifPresentOrElse(groups ->
+						variables.put(BuildUserVariable.GROUPS, groups)
+                    , () ->
+                        variables.put(BuildUserVariable.GROUPS, "")
+                    );
+        } catch (Exception err) {
+            log.warning(String.format("Failed to get groups for user: %s error: %s ", userId, err));
+        }
+    }
 
-			String groups = authorities.stream()
-					.map(GrantedAuthority::getAuthority)
-					.filter(authority -> authority != null && !authority.isEmpty())
-					.collect(Collectors.joining(","));
+    private void setUserEmail(String userId, Map<String, String> variables) {
+        Optional.ofNullable(User.getById(userId, false))
+                .map(user -> user.getProperty(UserProperty.class))
+                .map(UserProperty::getAddress)
+                .map(StringUtils::trimToEmpty)
+                .ifPresent(address -> variables.put(BuildUserVariable.EMAIL, address));
+    }
 
-			if (!groups.isEmpty()) {
-				variables.put(BuildUserVariable.GROUPS, groups);
-			}
-		} catch (Exception err) {
-			log.warning(String.format("Failed to get groups for user: %s error: %s ", userId, err));
-		}
-	}
-
-	private void setUserEmail(String userId, Map<String, String> variables) {
-		Optional.ofNullable(User.getById(userId, false))
-				.map(user -> user.getProperty(UserProperty.class))
-				.map(UserProperty::getAddress)
-				.map(StringUtils::trimToEmpty)
-				.ifPresent(address -> variables.put(BuildUserVariable.EMAIL, address));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public Class<UserIdCause> getUsedCauseClass() {
-		return UserIdCause.class;
-	}
+    /**
+     * {@inheritDoc}
+     */
+    public Class<UserIdCause> getUsedCauseClass() {
+        return UserIdCause.class;
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminantTest.java
+++ b/src/test/java/org/jenkinsci/plugins/builduser/varsetter/impl/UserIdCauseDeterminantTest.java
@@ -18,7 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class UserIdCauseDeterminantTest {
     public static final String TEST_USER = "test_user";
-    
+
     @Rule
     public JenkinsRule r = new JenkinsRule();
 
@@ -43,7 +43,7 @@ public class UserIdCauseDeterminantTest {
         UserIdCause cause = new UserIdCause(TEST_USER);
         UserIdCauseDeterminant determinant = new UserIdCauseDeterminant();
         determinant.setJenkinsUserBuildVars(cause, outputVars);
-        assertThat(outputVars.get(BuildUserVariable.GROUPS), is(equalTo("authenticated")));
+        assertThat(outputVars.get(BuildUserVariable.GROUPS), is(equalTo("")));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR fixes https://issues.jenkins.io/browse/JENKINS-73420
As described in https://github.com/jenkinsci/oic-auth-plugin/issues/343 the plugin functionality of providing groups is broken.
Tests for retrieving the groups are still working.

Breaking Change: 
Anonymous Users do no longer report the group "authenticated".

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
