### PR TITLE
[JENKINS-73699] Add support for GenericCause (generic-webhook-trigger plugin) to prevent warning logs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,12 @@
             <artifactId>branch-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>generic-webhook-trigger</artifactId>
+            <version>2.3.1</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/BuildUser.java
@@ -23,6 +23,7 @@ import jenkins.tasks.SimpleBuildWrapper;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
 import org.jenkinsci.plugins.builduser.varsetter.impl.*;
+import org.jenkinsci.plugins.gwt.GenericCause;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -114,6 +115,15 @@ public class BuildUser extends SimpleBuildWrapper {
         RemoteCause remoteTriggerCause = build.getCause(RemoteCause.class);
         if (new RemoteCauseDeterminant().setJenkinsUserBuildVars(remoteTriggerCause, variables)) {
             return;
+        }
+
+        try {
+            GenericCause genericCause = build.getCause(GenericCause.class);
+            if (new GenericCauseDeterminant().setJenkinsUserBuildVars(genericCause, variables)) {
+                return;
+            }
+        } catch (NoClassDefFoundError e) {
+            log.fine("It seems the generic-webhook-trigger-plugin is not installed, skipping.");
         }
 
         try {

--- a/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/GenericCauseDeterminant.java
+++ b/src/main/java/org/jenkinsci/plugins/builduser/varsetter/impl/GenericCauseDeterminant.java
@@ -1,0 +1,30 @@
+package org.jenkinsci.plugins.builduser.varsetter.impl;
+
+import org.jenkinsci.plugins.builduser.utils.BuildUserVariable;
+import org.jenkinsci.plugins.builduser.utils.UsernameUtils;
+import org.jenkinsci.plugins.builduser.varsetter.IUsernameSettable;
+import org.jenkinsci.plugins.gwt.GenericCause;
+
+import java.util.Map;
+
+public class GenericCauseDeterminant implements IUsernameSettable<GenericCause> {
+
+    protected static final String GENERIC_TRIGGER_DUMMY_USER_NAME = "Generic Webhook Trigger";
+    protected static final String GENERIC_TRIGGER_DUMMY_USER_ID = "genericWebhook";
+
+    @Override
+    public boolean setJenkinsUserBuildVars(GenericCause cause, Map<String, String> variables) {
+        if (cause == null) {
+            return false;
+        }
+
+        UsernameUtils.setUsernameVars(GENERIC_TRIGGER_DUMMY_USER_NAME, variables);
+        variables.put(BuildUserVariable.ID, GENERIC_TRIGGER_DUMMY_USER_ID);
+        return true;
+    }
+
+    @Override
+    public Class<GenericCause> getUsedCauseClass() {
+        return GenericCause.class;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/builduser/varsetter/impl/GenericCauseDeterminantTest.java
+++ b/src/test/java/org/jenkinsci/plugins/builduser/varsetter/impl/GenericCauseDeterminantTest.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.builduser.varsetter.impl;
+
+import org.easymock.EasyMock;
+import org.jenkinsci.plugins.builduser.utils.BuildUserVariable;
+import org.jenkinsci.plugins.gwt.GenericCause;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GenericCauseDeterminantTest {
+
+    @Test
+    void usedCauseClassIsGenericCause() {
+        assertThat(new GenericCauseDeterminant().getUsedCauseClass(), equalTo(GenericCause.class));
+    }
+
+    @Test
+    void setVarsReturnsFalseWithoutBuildUserVarsOnNullCause() {
+        Map<String,String> variables = new HashMap<>();
+        assertFalse(new GenericCauseDeterminant().setJenkinsUserBuildVars(null, variables));
+        assertThat(variables, equalTo(Collections.emptyMap()));
+    }
+
+    @Test
+    void setVarsReturnsTrueWithBuildUsersVarsOnValidCause() {
+        Map<String, String> variables = new HashMap<>();
+        GenericCause mockCause = EasyMock.createMock(GenericCause.class);
+        EasyMock.replay(mockCause);
+
+        assertTrue(new GenericCauseDeterminant().setJenkinsUserBuildVars(mockCause, variables));
+        assertThat(variables,
+                allOf(hasEntry(BuildUserVariable.USERNAME, GenericCauseDeterminant.GENERIC_TRIGGER_DUMMY_USER_NAME),
+                        hasEntry(BuildUserVariable.FIRST_NAME, "Generic"),
+                        hasEntry(BuildUserVariable.LAST_NAME, "Webhook"),
+                        hasEntry(BuildUserVariable.ID, GenericCauseDeterminant.GENERIC_TRIGGER_DUMMY_USER_ID)
+        ));
+
+        EasyMock.verify(mockCause);
+    }
+}


### PR DESCRIPTION
## Description
This PR addresses [JENKINS-73699](https://issues.jenkins.io/browse/JENKINS-73699) by properly handling the `GenericCause` from the generic-webhook-trigger plugin. Instead of logging warnings about unsupported cause type, the plugin now handles these cases gracefully by setting the following _dummy values_:

| Variable Name | Value |
|--------------|--------|
| BUILD_USER | "Generic Webhook Trigger" |
| BUILD_USER_FIRST_NAME | "Generic" |
| BUILD_USER_LAST_NAME | "Webhook" |
| BUILD_USER_ID | "genericWebhook" |

### Testing done

- Added unit tests for the new handler `GenericCauseDeterminant`.
- Verified that generic webhook triggers no longer produce warning logs in case of a job triggered by GWT.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
