### PR TITLE
Adapt build status icon for ci.jenkins.io permissions change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Build User Vars Plugin
 
-[![Build Status](https://ci.jenkins.io/job/Plugins/job/build-user-vars-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/Plugins/job/build-user-vars-plugin/job/master/)
+[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Fbuild-user-vars-plugin%2Fmaster)](https://ci.jenkins.io/job/Plugins/job/build-user-vars-plugin/job/master/)
 [![Coverage](https://ci.jenkins.io/job/Plugins/job/build-user-vars-plugin/job/master/badge/icon?status=${instructionCoverage}&subject=coverage&color=${colorInstructionCoverage})](https://ci.jenkins.io/job/Plugins/job/build-user-vars-plugin/job/master/coverage)
 [![Contributors](https://img.shields.io/github/contributors/jenkinsci/build-user-vars-plugin.svg)](https://github.com/jenkinsci/build-user-vars-plugin/graphs/contributors)
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/build-user-vars-plugin.svg)](https://plugins.jenkins.io/build-user-vars-plugin)


### PR DESCRIPTION
## Adapt build status icon for ci.jenkins.io permissions change

Large language models and other readers were causing performance problems.  The ci.jenkins.io controller has been reconfigured to limit access to authenticated users in order to prevent performance problems.  That change requires that we adjust the URL of the embeddable build status update URL.

### Testing done

* Validated the change in a sample repository
* Will check the pull request after it is submitted

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
